### PR TITLE
Add client stats widgets

### DIFF
--- a/src/apps/Clients/BasicInfo.jsx
+++ b/src/apps/Clients/BasicInfo.jsx
@@ -4,22 +4,35 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { mockClients } from "@/data/clients";
 import { Building, Contact, Pencil } from "lucide-react";
+import { mockProjects } from "@/data/projects";
+import StatsWidget from "@/components/Stats/StatsWidget";
+import BarChartSimple from "@/components/Stats/BarChartSimple";
 import ButtonPrimary from "@/components/Button/ButtonPrimary";
 import ModalSubmitClient from "@/components/Modal/ModalSubmitClient";
 
 const BasicInfo = () => {
   const [dataClient, setDataClient] = useState(null);
+  const [stats, setStats] = useState({ projects: 0, bill: 0, tasks: 0, chart: [] });
   // Handle Edit
   const [isEditOpen, setIsEditOpen] = useState(false);
   const handleAddClient = () => {
     setIsEditOpen(false);
   };
 
-  const { id } = useParams();
+const { id } = useParams();
 
-  useEffect(() => {
-    setDataClient(mockClients.find((item) => item.id === id));
-  }, [id]);
+useEffect(() => {
+  const found = mockClients.find((item) => item.id === id);
+  setDataClient(found);
+  const clientProjects = mockProjects.filter((p) => p.clientId === id);
+  const totalBill = clientProjects.reduce((sum, p) => sum + p.billOfMaterials, 0);
+  setStats({
+    projects: clientProjects.length,
+    bill: totalBill,
+    tasks: clientProjects.length * 5,
+    chart: clientProjects.slice(0, 5).map((p) => ({ label: p.name, value: p.billOfMaterials })),
+  });
+}, [id]);
 
   return (
     <div className="space-y-6">
@@ -91,6 +104,22 @@ const BasicInfo = () => {
               </a>
             </div>
           </div>
+        </div>
+      </div>
+      {/* Client statistics */}
+      <div className="space-y-6">
+        <h6 className="text-xl font-semibold">Client Statistics</h6>
+        <div className="grid grid-cols-3 gap-4">
+          <StatsWidget label="Total Projects" value={stats.projects} />
+          <StatsWidget
+            label="Total Bill of Materials"
+            value={`$${stats.bill}`}
+          />
+          <StatsWidget label="Completed Tasks" value={stats.tasks} />
+        </div>
+        <div className="bg-white border border-neutral-400 rounded-lg p-4">
+          <h6 className="text-sm font-semibold mb-2">Bill of Materials by Project</h6>
+          <BarChartSimple data={stats.chart} />
         </div>
       </div>
       <ModalSubmitClient

--- a/src/components/Stats/BarChartSimple.jsx
+++ b/src/components/Stats/BarChartSimple.jsx
@@ -1,0 +1,21 @@
+const BarChartSimple = ({ data }) => {
+  if (!data || data.length === 0) return null;
+  const max = Math.max(...data.map((d) => d.value));
+  return (
+    <div className="flex items-end gap-3 h-32 w-full">
+      {data.map((d, idx) => (
+        <div key={idx} className="flex flex-col items-center flex-1">
+          <div
+            className="w-full rounded-t-md bg-primary-200"
+            style={{ height: `${(d.value / max) * 100}%` }}
+          />
+          <span className="mt-1 text-xs text-center truncate w-full">
+            {d.label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BarChartSimple;

--- a/src/components/Stats/StatsWidget.jsx
+++ b/src/components/Stats/StatsWidget.jsx
@@ -1,0 +1,16 @@
+import clsx from "clsx";
+
+const StatsWidget = ({ label, value, className }) => {
+  return (
+    <div
+      className={clsx(
+        "p-4 rounded-lg border border-neutral-400 bg-white", className
+      )}
+    >
+      <p className="text-xs text-secondary">{label}</p>
+      <p className="text-2xl font-semibold">{value}</p>
+    </div>
+  );
+};
+
+export default StatsWidget;

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -1,19 +1,23 @@
 // src/data/projects.js
 import { v4 as uuidv4 } from "uuid";
 import { dropdownProgress } from "./dropdown";
+import { mockClients } from "./clients";
 
 const generateRandomDate = () => Math.floor(Math.random() * 100).toString().padStart(2, '0') + (Math.floor(Math.random() * 9) + 1) + (Math.floor(Math.random() * 9) + 1) + Math.floor(Math.random() * 1000).toString().padStart(3, '0');
 
 export const mockProjects = Array.from({ length: 200 }).map((_, i) => {
   const randomStage = dropdownProgress[Math.floor(Math.random() * dropdownProgress.length)];
-  const random=generateRandomDate()
+  const random = generateRandomDate();
+  const client = mockClients[Math.floor(Math.random() * mockClients.length)];
   return {
     id: random,
     name: `Project ${i + 1}`,
     number: random,
     stage: randomStage.name,
     stage_id: randomStage.id,
-    clientOrganization: `Client Organization ${i + 1}`,
+    clientId: client.id,
+    clientOrganization: client.name,
+    billOfMaterials: Math.floor(Math.random() * 4000) + 1000,
     isArchive: Math.random() < 0.5,
   };
 });


### PR DESCRIPTION
## Summary
- generate clientId and billOfMaterials in mockProjects
- display client statistics in Basic Info tab
- create StatsWidget and BarChartSimple components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68782b84634483339c3bc3a4adca4948